### PR TITLE
Use GitHub username to lookup slackId

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ steps:
   - label: ":slack: Notify on fail"
     if: build.branch == "main"
     plugins:
-      - envato/build-failed-notify-slack#v1.0.0:
+      - envato/build-failed-notify-slack#v1.1.0:
           mapping_file: slack_users.json
           channel: "#my-channel"
 ```
@@ -27,7 +27,7 @@ steps:
     plugins:
       - cultureamp/aws-assume-role#v0.2.0:
           role: "arn:aws:iam::123456789012:role/example-role"
-      - envato/build-failed-notify-slack#v1.0.0:
+      - envato/build-failed-notify-slack#v1.1.0:
           mapping_file: s3://my-bucket/slack_users.json
           channel: "#my-channel"
 ```

--- a/lib/pipeline.bash
+++ b/lib/pipeline.bash
@@ -17,7 +17,8 @@ function pipeline() {
   branch="${BUILDKITE_BRANCH:-main}"
 
   if [[ -f "$mapping_file" ]]; then
-    slackId=$(jq -r ".[] | select(.email==\"$email\").slackId" < "$mapping_file")
+    # Lookup the email address first, fallback to looking up github username
+    slackId=$(jq -r ".[] | select(.email==\"$email\" or .github==\"$creator\").slackId" < "$mapping_file")
   fi
 
   if [[ -n "${slackId-}" ]]; then

--- a/tests/fixture2.json
+++ b/tests/fixture2.json
@@ -1,0 +1,12 @@
+[
+  {
+    "email": "me@example.com",
+    "slackId": "U1234",
+    "github": "dev1"
+  },
+  {
+    "email": "other@example.com",
+    "slackId": "U5678",
+    "github": "dev2"
+  }
+]

--- a/tests/pipeline.bats
+++ b/tests/pipeline.bats
@@ -55,6 +55,28 @@ EOM
   stub aws
 }
 
+@test "looks up the slackId based on github username in a json file" {
+  export BUILDKITE_PLUGIN_BUILD_FAILED_NOTIFY_SLACK_CHANNEL="#my-channel"
+  export BUILDKITE_PLUGIN_BUILD_FAILED_NOTIFY_SLACK_MAPPING_FILE=tests/fixture2.json
+  export BUILDKITE_BUILD_CREATOR_EMAIL=dev1@users.noreply.github.com
+  export BUILDKITE_BUILD_CREATOR=dev1
+  export BUILDKITE_BRANCH=main
+
+  run pipeline
+
+  assert_success
+  assert_output << EOM
+steps: []
+
+notify:
+  - slack:
+      channels:
+        - "#my-channel"
+      message: "The most recent \`main\` branch build by <@U1234> has failed, please take a look."
+    if: build.state == "failed"
+EOM
+}
+
 @test "can gracefully fail the lookup" {
   export BUILDKITE_PLUGIN_BUILD_FAILED_NOTIFY_SLACK_CHANNEL="#my-channel"
   export BUILDKITE_PLUGIN_BUILD_FAILED_NOTIFY_SLACK_MAPPING_FILE=tests/fixture.json


### PR DESCRIPTION
Add support for looking up creator with github username. This applies when Buildkite is unable to use verify the commit email address